### PR TITLE
Fix server crash: repair OpenRouter chatbot integration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "express-rate-limit": "^8.3.1",
     "ioredis": "^5.3.2",
     "node-fetch": "^2.7.0",
+    "openai": "^4.104.0",
     "pg": "^8.11.3",
     "stripe": "^22.1.1"
   },

--- a/backend/routes/warroom.js
+++ b/backend/routes/warroom.js
@@ -25,30 +25,40 @@ const router = express.Router();
 // (the $1/month Stripe plan) — checked against the subscriptions table that
 // the Stripe webhook maintains, with a live Stripe lookup as fallback.
 // ---------------------------------------------------------------------------
-const { OpenAI } = require('openai');
-
-const openRouterClient = new OpenAI({
-  baseURL: "https://openrouter.ai",
-  apiKey: process.env.OPENROUTER_API_KEY, // Make sure to put your sk-or-v1-... key in your .env file
-});
-
-
 const STARTING_BALANCE = 1000;
 const stripeSecret = process.env.STRIPE_SECRET_KEY || "";
 const stripe = stripeSecret ? require("stripe")(stripeSecret) : null;
 
+// Chat engines, in order of preference:
+//   1. Anthropic (ANTHROPIC_API_KEY) — Claude via the official SDK
+//   2. OpenRouter (OPENROUTER_API_KEY, sk-or-v1-...) — free/cheap models
+//      via the OpenAI-compatible endpoint
+//   3. Built-in fallback responder (no key needed)
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || "";
-const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || "meta-llama/llama-3-8b-instruct:free"; // <-- Change model here
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || "claude-opus-4-8";
 let anthropicClient = null;
 if (ANTHROPIC_API_KEY) {
   try {
     const Anthropic = require("@anthropic-ai/sdk");
-    anthropicClient = new Anthropic({ 
-      apiKey: ANTHROPIC_API_KEY,
-      baseURL: "https://openrouter.ai" // <-- ADD THIS LINE
-    });
+    anthropicClient = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
   } catch (err) {
     console.error("[warroom] anthropic sdk unavailable:", err.message);
+  }
+}
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || "";
+const OPENROUTER_MODEL =
+  process.env.OPENROUTER_MODEL || "meta-llama/llama-3-8b-instruct:free";
+let openRouterClient = null;
+if (OPENROUTER_API_KEY) {
+  try {
+    const { OpenAI } = require("openai");
+    openRouterClient = new OpenAI({
+      baseURL: "https://openrouter.ai/api/v1",
+      apiKey: OPENROUTER_API_KEY
+    });
+  } catch (err) {
+    console.error("[warroom] openai sdk unavailable:", err.message);
   }
 }
 
@@ -611,8 +621,7 @@ router.post("/chat", requirePro, chatLimiter, async (req, res) => {
 
     const board = await marketContext();
 
-        // Safety check updated to use your new OpenRouter client
-    if (!openRouterClient) {
+    if (!anthropicClient && !openRouterClient) {
       return res.json({
         reply: fallbackReply(history[history.length - 1].content, board),
         engine: "builtin"
@@ -629,35 +638,41 @@ router.post("/chat", requirePro, chatLimiter, async (req, res) => {
       "Current market board (YES price in cents = crowd probability):\n" +
       (board || "(no open markets)");
 
-        // Swapped from Anthropic to OpenRouter Free Router
-    const response = await openRouterClient.chat.completions.create({
-      model: "openrouter/free", // Automatically picks from available 100% free models
-      max_tokens: 1024,
-      messages: [
-        { role: "system", content: system },
-        ...history
-      ]
-    });
+    let reply = "";
+    let engine = "";
 
+    if (anthropicClient) {
+      engine = "claude";
+      const response = await anthropicClient.messages.create({
+        model: ANTHROPIC_MODEL,
+        max_tokens: 1024,
+        system,
+        messages: history
+      });
+      reply = response.content
+        .filter((b) => b.type === "text")
+        .map((b) => b.text)
+        .join("\n")
+        .trim();
+      if (response.stop_reason === "refusal") reply = "";
+    } else {
+      engine = "openrouter";
+      const response = await openRouterClient.chat.completions.create({
+        model: OPENROUTER_MODEL,
+        max_tokens: 1024,
+        messages: [{ role: "system", content: system }, ...history]
+      });
+      reply = String(response.choices?.[0]?.message?.content || "").trim();
+    }
 
-    const reply = response.content
-      .filter((b) => b.type === "text")
-      .map((b) => b.text)
-      .join("\n")
-      .trim();
-
-    if (response.stop_reason === "refusal" || !reply) {
+    if (!reply) {
       return res.json({
         reply: "I can't help with that one — try me on Cowboys odds or the markets.",
-        engine: "claude"
+        engine
       });
     }
 
-    // Extract the text message using the OpenRouter/OpenAI response format
-    const reply = response.choices[0].message.content;
-
-    // Send the response back to your Dallas Cowboys dashboard
-    res.json({ reply, engine: "openrouter" });
+    res.json({ reply, engine });
   } catch (error) {
     console.error("[warroom] chat failed:", error);
     res.status(500).json({ error: "The analyst dropped the headset. Try again." });


### PR DESCRIPTION
## Summary
The manual OpenRouter edit in `backend/routes/warroom.js` crashed the server at boot. This PR fixes the crash while keeping the intended free OpenRouter-powered chatbot.

## Root cause (four bugs)
1. `require('openai')` for a package that was never installed → server dies on startup
2. `const reply` declared twice in the same scope → SyntaxError
3. `new OpenAI({ apiKey: undefined })` constructed unconditionally → throws when no key is set
4. Wrong base URL (`https://openrouter.ai` instead of `https://openrouter.ai/api/v1`), and the Anthropic client was also pointed at OpenRouter

## Fix
- `openai` added to backend dependencies
- OpenRouter client built only when `OPENROUTER_API_KEY` is set, against the correct `/api/v1` endpoint; model configurable via `OPENROUTER_MODEL` (default `meta-llama/llama-3-8b-instruct:free`)
- Anthropic client restored to the real Anthropic API, preferred when `ANTHROPIC_API_KEY` is set; built-in responder remains the no-key fallback
- Chat route parses each engine's own response format with a single reply path

## Testing
- `node --check` passes; module loads with no keys and with `OPENROUTER_API_KEY` set
- 15-check War Room smoke test passes (paywall, betting, payouts, chat fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDcSUtGdkAWcmGxyZ2HjPE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDcSUtGdkAWcmGxyZ2HjPE)_