### PR TITLE
Add Perfect Season game mode (82-0-inspired) with mode switcher

### DIFF
--- a/backend/routes/warroom.js
+++ b/backend/routes/warroom.js
@@ -537,6 +537,49 @@ router.post("/markets/:id/resolve", async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// Perfect Season game — pays Star Coins for a completed season.
+// 5 coins per win, +500 for a perfect 20-0. One reward per minute per user.
+// ---------------------------------------------------------------------------
+
+const seasonRewardAt = new Map(); // email -> last reward timestamp
+
+router.post("/season/reward", requirePro, async (req, res) => {
+  try {
+    await ensureTables();
+    const wins = Math.floor(Number(req.body.wins));
+    if (!Number.isFinite(wins) || wins < 0 || wins > 20) {
+      return res.status(400).json({ error: "Invalid season result." });
+    }
+
+    const last = seasonRewardAt.get(req.warRoomEmail) || 0;
+    if (Date.now() - last < 60 * 1000) {
+      return res.status(429).json({
+        error: "Take a breather, coach — one season reward per minute."
+      });
+    }
+    seasonRewardAt.set(req.warRoomEmail, Date.now());
+
+    const perfect = wins === 20;
+    const reward = wins * 5 + (perfect ? 500 : 0);
+    await getWallet(req.warRoomEmail);
+    const { rows } = await db.query(
+      `UPDATE wr_wallets SET balance = balance + $2, updated_at = CURRENT_TIMESTAMP
+       WHERE email = $1 RETURNING balance`,
+      [req.warRoomEmail, reward]
+    );
+    res.json({
+      ok: true,
+      reward,
+      perfect,
+      balance: Number(rows[0].balance)
+    });
+  } catch (error) {
+    console.error("[warroom] season reward failed:", error);
+    res.status(500).json({ error: "Unable to record the season." });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Chatbot (Pro only)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -397,6 +397,13 @@
     });
   }
 
+  function claimSeasonReward(wins) {
+    return request("/api/warroom/season/reward", {
+      method: "POST",
+      body: { wins }
+    });
+  }
+
   function startProCheckout() {
     return request("/api/billing/create-checkout-session", {
       method: "POST",
@@ -442,5 +449,6 @@
     placeWarRoomBet,
     getWarRoomLeaderboard,
     sendWarRoomChat,
+    claimSeasonReward,
     startProCheckout
   };

--- a/frontend/src/components/PerfectSeason.jsx
+++ b/frontend/src/components/PerfectSeason.jsx
@@ -1,0 +1,476 @@
+import React, { useEffect, useRef, useState } from "react";
+import { api } from "../api";
+
+/*
+ * Perfect Season — the War Room's second game mode, inspired by 82-0.com.
+ * Spin the wheel for an era of Cowboys history, draft an all-time roster
+ * from each pool, then play a 20-game season one reveal at a time chasing
+ * 20-0. Wins pay out Star Coins into the same wallet as the markets.
+ */
+
+const ERAS = [
+  {
+    name: "'70s Doomsday",
+    players: [
+      { name: "Roger Staubach", pos: "QB", rating: 94 },
+      { name: "Tony Dorsett", pos: "RB", rating: 93 },
+      { name: "Drew Pearson", pos: "WR", rating: 90 },
+      { name: "Billy Joe DuPree", pos: "TE", rating: 86 },
+      { name: "Rayfield Wright", pos: "OL", rating: 92 },
+      { name: "Bob Lilly", pos: "DL", rating: 96 },
+      { name: "Randy White", pos: "DL", rating: 95 },
+      { name: "Chuck Howley", pos: "LB", rating: 93 },
+      { name: "Cliff Harris", pos: "DB", rating: 91 },
+      { name: "Mel Renfro", pos: "DB", rating: 93 }
+    ]
+  },
+  {
+    name: "'90s Dynasty",
+    players: [
+      { name: "Troy Aikman", pos: "QB", rating: 93 },
+      { name: "Emmitt Smith", pos: "RB", rating: 97 },
+      { name: "Michael Irvin", pos: "WR", rating: 94 },
+      { name: "Jay Novacek", pos: "TE", rating: 87 },
+      { name: "Larry Allen", pos: "OL", rating: 98 },
+      { name: "Erik Williams", pos: "OL", rating: 90 },
+      { name: "Charles Haley", pos: "DL", rating: 92 },
+      { name: "Ken Norton Jr.", pos: "LB", rating: 88 },
+      { name: "Deion Sanders", pos: "DB", rating: 98 },
+      { name: "Darren Woodson", pos: "DB", rating: 92 }
+    ]
+  },
+  {
+    name: "'00s Grit",
+    players: [
+      { name: "Tony Romo", pos: "QB", rating: 89 },
+      { name: "Marion Barber", pos: "RB", rating: 84 },
+      { name: "Terrell Owens", pos: "WR", rating: 93 },
+      { name: "Jason Witten", pos: "TE", rating: 93 },
+      { name: "Flozell Adams", pos: "OL", rating: 87 },
+      { name: "La'Roi Glover", pos: "DL", rating: 88 },
+      { name: "DeMarcus Ware", pos: "LB", rating: 96 },
+      { name: "Terence Newman", pos: "DB", rating: 86 },
+      { name: "Roy Williams", pos: "DB", rating: 87 },
+      { name: "Miles Austin", pos: "WR", rating: 85 }
+    ]
+  },
+  {
+    name: "'10s Squad",
+    players: [
+      { name: "Dak Prescott", pos: "QB", rating: 88 },
+      { name: "Ezekiel Elliott", pos: "RB", rating: 92 },
+      { name: "Dez Bryant", pos: "WR", rating: 91 },
+      { name: "Cole Beasley", pos: "WR", rating: 84 },
+      { name: "Tyron Smith", pos: "OL", rating: 95 },
+      { name: "Zack Martin", pos: "OL", rating: 96 },
+      { name: "DeMarcus Lawrence", pos: "DL", rating: 89 },
+      { name: "Sean Lee", pos: "LB", rating: 90 },
+      { name: "Byron Jones", pos: "DB", rating: 87 },
+      { name: "Travis Frederick", pos: "OL", rating: 93 }
+    ]
+  },
+  {
+    name: "'20s Stars",
+    players: [
+      { name: "Dak Prescott", pos: "QB", rating: 90 },
+      { name: "Tony Pollard", pos: "RB", rating: 86 },
+      { name: "CeeDee Lamb", pos: "WR", rating: 94 },
+      { name: "Jake Ferguson", pos: "TE", rating: 84 },
+      { name: "Zack Martin", pos: "OL", rating: 94 },
+      { name: "Osa Odighizuwa", pos: "DL", rating: 85 },
+      { name: "Micah Parsons", pos: "LB", rating: 97 },
+      { name: "Trevon Diggs", pos: "DB", rating: 90 },
+      { name: "DaRon Bland", pos: "DB", rating: 89 },
+      { name: "Brandin Cooks", pos: "WR", rating: 84 }
+    ]
+  }
+];
+
+const SLOTS = ["QB", "RB", "WR", "TE", "OL", "DL", "LB", "DB"];
+
+const OPPONENTS = [
+  { name: "'03 Panthers", rating: 87 },
+  { name: "'11 Giants", rating: 88 },
+  { name: "'17 Eagles", rating: 90 },
+  { name: "'92 Redskins", rating: 90 },
+  { name: "'21 Rams", rating: 90 },
+  { name: "'12 Broncos", rating: 90 },
+  { name: "'15 Panthers", rating: 91 },
+  { name: "'06 Colts", rating: 91 },
+  { name: "'08 Steelers", rating: 91 },
+  { name: "'86 Giants", rating: 92 },
+  { name: "'19 Ravens", rating: 92 },
+  { name: "'23 49ers", rating: 92 },
+  { name: "'96 Packers", rating: 93 },
+  { name: "'98 Broncos", rating: 93 },
+  { name: "'99 Rams", rating: 93 },
+  { name: "'13 Seahawks", rating: 94 },
+  { name: "'00 Ravens", rating: 94 },
+  { name: "'20 Chiefs", rating: 94 },
+  { name: "'75 Steelers", rating: 95 },
+  { name: "'89 49ers", rating: 95 },
+  { name: "'07 Patriots", rating: 96 },
+  { name: "'85 Bears", rating: 97 }
+];
+
+function shuffle(list) {
+  const a = [...list];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function buildSchedule() {
+  // 17 regular-season games easiest-to-hardest-ish, then 3 playoff monsters.
+  const pool = shuffle(OPPONENTS);
+  const regular = pool.slice(0, 17).sort((x, y) => x.rating - y.rating);
+  const playoffs = shuffle(OPPONENTS.filter((o) => o.rating >= 94)).slice(0, 3);
+  return regular.concat(playoffs).map((o, i) => ({
+    ...o,
+    week: i + 1,
+    playoff: i >= 17
+  }));
+}
+
+function rollPool(era, roster) {
+  const openSlots = new Set(SLOTS.filter((s) => !roster[s]));
+  const pool = shuffle(era.players).slice(0, 7);
+  // Guarantee at least one pickable card so the draft can't dead-end.
+  if (!pool.some((p) => openSlots.has(p.pos))) {
+    const rescue = era.players.find((p) => openSlots.has(p.pos));
+    if (rescue) pool[0] = rescue;
+  }
+  return pool;
+}
+
+function teamRating(roster) {
+  const picks = SLOTS.map((s) => roster[s]).filter(Boolean);
+  if (!picks.length) return 0;
+  return picks.reduce((sum, p) => sum + p.rating, 0) / picks.length;
+}
+
+function winProbability(team, opp) {
+  return 1 / (1 + Math.pow(10, (opp - (team + 1.5)) / 10));
+}
+
+export default function PerfectSeason({ onReward }) {
+  const [phase, setPhase] = useState("idle"); // idle | spin | draft | ready | season | done
+  const [era, setEra] = useState(null);
+  const [spinName, setSpinName] = useState(ERAS[0].name);
+  const [roster, setRoster] = useState({});
+  const [pool, setPool] = useState([]);
+  const [skips, setSkips] = useState(3);
+  const [schedule, setSchedule] = useState([]);
+  const [gameIndex, setGameIndex] = useState(0);
+  const [results, setResults] = useState([]); // "W" | "L"
+  const [stamp, setStamp] = useState(null); // result of the game on screen
+  const [reward, setReward] = useState(null);
+  const timers = useRef([]);
+
+  useEffect(() => () => timers.current.forEach(clearTimeout), []);
+  function later(fn, ms) {
+    timers.current.push(setTimeout(fn, ms));
+  }
+
+  const rosterFull = SLOTS.every((s) => roster[s]);
+  const wins = results.filter((r) => r === "W").length;
+  const losses = results.filter((r) => r === "L").length;
+
+  function spinWheel(nextRoster) {
+    setPhase("spin");
+    let ticks = 0;
+    const interval = setInterval(() => {
+      ticks += 1;
+      setSpinName(ERAS[Math.floor(Math.random() * ERAS.length)].name);
+      if (ticks >= 12) {
+        clearInterval(interval);
+        const landed = ERAS[Math.floor(Math.random() * ERAS.length)];
+        setEra(landed);
+        setSpinName(landed.name);
+        later(() => {
+          setPool(rollPool(landed, nextRoster));
+          setPhase("draft");
+        }, 350);
+      }
+    }, 90);
+    timers.current.push(interval);
+  }
+
+  function startDraft() {
+    setRoster({});
+    setResults([]);
+    setGameIndex(0);
+    setStamp(null);
+    setReward(null);
+    setSkips(3);
+    spinWheel({});
+  }
+
+  function pick(player) {
+    if (roster[player.pos]) return;
+    const next = { ...roster, [player.pos]: player };
+    setRoster(next);
+    if (SLOTS.every((s) => next[s])) {
+      setPhase("ready");
+    } else {
+      spinWheel(next);
+    }
+  }
+
+  function skip() {
+    if (skips < 1 || !era) return;
+    setSkips(skips - 1);
+    spinWheel(roster);
+  }
+
+  function playSeason() {
+    const sched = buildSchedule();
+    setSchedule(sched);
+    setResults([]);
+    setGameIndex(0);
+    setStamp(null);
+    setPhase("season");
+    playGame(sched, 0, [], teamRating(roster));
+  }
+
+  function playGame(sched, index, resultsSoFar, rating) {
+    setGameIndex(index);
+    setStamp(null);
+    later(() => {
+      const won = Math.random() < winProbability(rating, sched[index].rating);
+      const outcome = won ? "W" : "L";
+      const nextResults = [...resultsSoFar, outcome];
+      setStamp(outcome);
+      setResults(nextResults);
+      later(() => {
+        if (!won || index + 1 >= sched.length) {
+          setPhase("done");
+        } else {
+          playGame(sched, index + 1, nextResults, rating);
+        }
+      }, 1250);
+    }, 950);
+  }
+
+  // Claim Star Coins once when the season ends.
+  useEffect(() => {
+    if (phase !== "done" || reward !== null) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api.claimSeasonReward(wins);
+        if (!cancelled) {
+          setReward(data);
+          if (onReward && data && typeof data.balance === "number") {
+            onReward(data.balance);
+          }
+        }
+      } catch (_err) {
+        if (!cancelled) setReward({ ok: false });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]);
+
+  const perfect = phase === "done" && wins === schedule.length && losses === 0;
+  const currentGame = schedule[gameIndex];
+
+  return (
+    <div className="ps">
+      {phase === "idle" ? (
+        <div className="ps-splash ps-pop">
+          <div className="ps-kicker">Game mode</div>
+          <h2 className="ps-headline">
+            Can you go <span className="ps-score">20–0</span>?
+          </h2>
+          <p className="ps-copy">
+            Spin the wheel for an era of Cowboys history. Draft an all-time
+            roster, one pool at a time. Then survive twenty of the greatest
+            teams ever assembled — lose once and the season is over. Every win
+            pays Star Coins.
+          </p>
+          <button className="wr-btn ps-cta" onClick={startDraft}>
+            Spin the wheel
+          </button>
+        </div>
+      ) : null}
+
+      {phase === "spin" ? (
+        <div className="ps-spin ps-pop">
+          <div className="ps-kicker">Scouting era…</div>
+          <div className="ps-slot" aria-live="polite">
+            <span className="ps-slot__name">{spinName}</span>
+          </div>
+        </div>
+      ) : null}
+
+      {phase === "draft" || phase === "ready" ? (
+        <div className="ps-draft ps-pop">
+          <div className="ps-draft__head">
+            <div>
+              <div className="ps-kicker">{era ? era.name : ""} · draft board</div>
+              <h3 className="ps-subhead">
+                {phase === "ready"
+                  ? "Roster complete."
+                  : "Pick one player to fill an open slot."}
+              </h3>
+            </div>
+            {phase === "draft" ? (
+              <button
+                className="ps-skip"
+                onClick={skip}
+                disabled={skips < 1}
+                title="Re-spin this pool"
+              >
+                Skip pool · {skips} left
+              </button>
+            ) : null}
+          </div>
+
+          {phase === "draft" ? (
+            <div className="ps-pool">
+              {pool.map((p, i) => {
+                const taken = Boolean(roster[p.pos]);
+                return (
+                  <button
+                    key={`${p.name}-${i}`}
+                    className={`ps-card ${taken ? "is-taken" : ""}`}
+                    style={{ animationDelay: `${i * 60}ms` }}
+                    onClick={() => pick(p)}
+                    disabled={taken}
+                  >
+                    <span className="ps-card__pos">{p.pos}</span>
+                    <span className="ps-card__name">{p.name}</span>
+                    <span className="ps-card__rating">{p.rating}</span>
+                    {taken ? <span className="ps-card__note">slot filled</span> : null}
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+
+          <div className="ps-roster">
+            {SLOTS.map((s) => (
+              <div key={s} className={`ps-slotbox ${roster[s] ? "is-filled" : ""}`}>
+                <span className="ps-slotbox__pos">{s}</span>
+                <span className="ps-slotbox__name">
+                  {roster[s] ? roster[s].name : "—"}
+                </span>
+                {roster[s] ? (
+                  <span className="ps-slotbox__rating">{roster[s].rating}</span>
+                ) : null}
+              </div>
+            ))}
+          </div>
+
+          {phase === "ready" ? (
+            <div className="ps-ready ps-pop">
+              <div className="ps-ready__rating">
+                Team rating <strong>{teamRating(roster).toFixed(1)}</strong>
+              </div>
+              <button className="wr-btn ps-cta" onClick={playSeason}>
+                Play the season
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {phase === "season" && currentGame ? (
+        <div className="ps-season">
+          <div className="ps-scoreline">
+            <span className="ps-kicker">
+              {currentGame.playoff ? "Playoffs" : `Week ${currentGame.week}`}
+            </span>
+            <span className="ps-record">
+              {wins}–{losses}
+            </span>
+          </div>
+          <div className="ps-matchup ps-pop" key={gameIndex}>
+            <div className="ps-matchup__side">
+              <span className="ps-matchup__team">Your Cowboys</span>
+              <span className="ps-matchup__rating">{teamRating(roster).toFixed(0)}</span>
+            </div>
+            <span className="ps-matchup__vs">vs</span>
+            <div className="ps-matchup__side">
+              <span className="ps-matchup__team">{currentGame.name}</span>
+              <span className="ps-matchup__rating">{currentGame.rating}</span>
+            </div>
+            {stamp ? (
+              <span className={`ps-stamp ${stamp === "W" ? "ps-stamp--w" : "ps-stamp--l"}`}>
+                {stamp === "W" ? "WIN" : "LOSS"}
+              </span>
+            ) : (
+              <span className="ps-matchup__dots">
+                <span />
+                <span />
+                <span />
+              </span>
+            )}
+          </div>
+          <div className="ps-strip">
+            {schedule.map((g, i) => (
+              <span
+                key={i}
+                className={`ps-strip__dot ${
+                  results[i] === "W" ? "is-w" : results[i] === "L" ? "is-l" : ""
+                } ${i === gameIndex ? "is-now" : ""}`}
+                title={g.name}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {phase === "done" ? (
+        <div className={`ps-final ps-pop ${losses ? "ps-final--loss" : "ps-final--perfect"}`}>
+          {perfect ? (
+            <div className="ps-confetti" aria-hidden="true">
+              {Array.from({ length: 26 }).map((_, i) => (
+                <span
+                  key={i}
+                  style={{
+                    left: `${(i * 137) % 100}%`,
+                    animationDelay: `${(i % 9) * 0.18}s`
+                  }}
+                />
+              ))}
+            </div>
+          ) : null}
+          <div className="ps-kicker">{perfect ? "Immortality" : "Final"}</div>
+          <h2 className="ps-headline">
+            <span className="ps-score">
+              {wins}–{losses}
+            </span>
+          </h2>
+          <p className="ps-copy">
+            {perfect
+              ? "A perfect season. Canton is calling — they're naming a wing after you."
+              : losses
+              ? `${schedule[gameIndex] ? schedule[gameIndex].name : "The football gods"} ended the dream${wins > 0 ? ` at ${wins}–0` : ""}. Spin again, coach.`
+              : "Season complete."}
+          </p>
+          <div className="ps-reward">
+            {reward && reward.ok !== false ? (
+              <>
+                +{reward.reward} Star Coins{perfect ? " · perfect-season bonus included" : ""}
+              </>
+            ) : reward ? (
+              "Reward unavailable right now — coins next time."
+            ) : (
+              "Counting your winnings…"
+            )}
+          </div>
+          <button className="wr-btn ps-cta" onClick={startDraft}>
+            Run it back
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/WarRoomPage.jsx
+++ b/frontend/src/components/WarRoomPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { api } from "../api";
+import PerfectSeason from "./PerfectSeason";
 
 /*
  * War Room — Pro-only page.
@@ -276,6 +277,7 @@ export default function WarRoomPage() {
   const [error, setError] = useState("");
   const [betting, setBetting] = useState(false);
   const [flash, setFlash] = useState("");
+  const [mode, setMode] = useState("markets"); // markets | season
 
   async function loadMarkets() {
     const data = await api.getWarRoomMarkets();
@@ -392,10 +394,32 @@ export default function WarRoomPage() {
         </div>
       </header>
 
+      <nav className="wr-modes" aria-label="Game mode">
+        <button
+          className={`wr-mode ${mode === "markets" ? "is-active" : ""}`}
+          onClick={() => setMode("markets")}
+        >
+          The Markets
+        </button>
+        <button
+          className={`wr-mode ${mode === "season" ? "is-active" : ""}`}
+          onClick={() => setMode("season")}
+        >
+          Perfect Season
+          <span className="wr-mode__tag">Game</span>
+        </button>
+      </nav>
+
       {flash ? <div className="wr-flash">{flash}</div> : null}
 
       <div className="wr-layout">
-        <div className="wr-left">
+        <div className="wr-left" key={mode}>
+          {mode === "season" ? (
+            <PerfectSeason
+              onReward={(balance) => setWallet((w) => ({ ...(w || {}), balance }))}
+            />
+          ) : (
+          <>
           <div className="wr-markets">
             {markets.map((m) => (
               <MarketCard key={m.id} market={m} onBet={handleBet} busy={betting} />
@@ -421,6 +445,8 @@ export default function WarRoomPage() {
               <div className="wr-board__note">Net worth = balance + open stakes</div>
             </section>
           ) : null}
+          </>
+          )}
         </div>
         <ChatPanel />
       </div>

--- a/frontend/src/styles/WarRoom.css
+++ b/frontend/src/styles/WarRoom.css
@@ -872,3 +872,545 @@
     padding-left: 0;
   }
 }
+
+/* ── Mode tabs (Markets ↔ Perfect Season) ──────────────────── */
+
+.wr-modes {
+  display: flex;
+  gap: 22px;
+  margin: -6px 0 16px;
+  border-bottom: 1px solid var(--wr-rule);
+}
+
+.wr-mode {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 2px 10px;
+  background: none;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  color: var(--wr-meta);
+  font-family: var(--wr-sans);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.wr-mode:hover {
+  color: var(--wr-ink);
+}
+
+.wr-mode.is-active {
+  color: var(--wr-ink);
+  border-bottom-color: var(--wr-ink);
+}
+
+.wr-mode__tag {
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  padding: 2px 6px;
+  border: 1px solid var(--wr-live);
+  border-radius: 2px;
+  color: var(--wr-live);
+}
+
+/* ── Perfect Season game ───────────────────────────────────── */
+
+.ps {
+  min-height: 420px;
+  padding-right: 2px;
+}
+
+.ps-pop {
+  animation: ps-pop 0.4s cubic-bezier(0.2, 0.9, 0.3, 1.15) both;
+}
+
+@keyframes ps-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.94) translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.ps-kicker {
+  font-family: var(--wr-sans);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--wr-meta);
+  margin-bottom: 8px;
+}
+
+.ps-headline {
+  margin: 0 0 12px;
+  color: var(--wr-ink);
+  font-family: var(--wr-serif);
+  font-size: 2.4rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.ps-score {
+  font-variant-numeric: tabular-nums;
+}
+
+.ps-subhead {
+  margin: 0;
+  color: var(--wr-ink);
+  font-family: var(--wr-serif);
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.ps-copy {
+  margin: 0 0 20px;
+  max-width: 460px;
+  font-family: var(--wr-serif);
+  font-size: 14px;
+  color: var(--wr-ink-2);
+  line-height: 1.6;
+}
+
+.ps-cta {
+  padding: 12px 26px;
+  font-size: 12px;
+}
+
+.ps-splash,
+.ps-final {
+  padding: 40px 0 24px;
+  text-align: center;
+  position: relative;
+}
+
+.ps-splash .ps-copy,
+.ps-final .ps-copy {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Slot machine */
+.ps-spin {
+  padding: 56px 0;
+  text-align: center;
+}
+
+.ps-slot {
+  display: inline-block;
+  min-width: 260px;
+  padding: 18px 26px;
+  border-top: 3px double var(--wr-rule-dark);
+  border-bottom: 3px double var(--wr-rule-dark);
+}
+
+.ps-slot__name {
+  display: inline-block;
+  font-family: var(--wr-serif);
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--wr-ink);
+  animation: ps-reel 0.09s linear infinite;
+}
+
+@keyframes ps-reel {
+  0% { transform: translateY(-2px); opacity: 0.7; }
+  50% { transform: translateY(0); opacity: 1; }
+  100% { transform: translateY(2px); opacity: 0.7; }
+}
+
+/* Draft board */
+.ps-draft__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 12px;
+  padding: 12px 0;
+}
+
+.ps-skip {
+  padding: 7px 12px;
+  background: none;
+  border: 1px solid #3a4560;
+  border-radius: 3px;
+  color: var(--wr-ink);
+  font-family: var(--wr-sans);
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+.ps-skip:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.ps-pool {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.ps-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px;
+  background: transparent;
+  border: 1px solid #3a4560;
+  border-radius: 3px;
+  color: var(--wr-ink);
+  text-align: left;
+  cursor: pointer;
+  animation: ps-deal 0.35s ease both;
+  transition: border-color 0.12s ease, background 0.12s ease, transform 0.12s ease;
+}
+
+@keyframes ps-deal {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ps-card:hover:not(:disabled) {
+  border-color: var(--wr-yes);
+  background: #141a29;
+  transform: translateY(-2px);
+}
+
+.ps-card.is-taken {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.ps-card__pos {
+  font-family: var(--wr-sans);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--wr-meta);
+}
+
+.ps-card__name {
+  font-family: var(--wr-serif);
+  font-size: 14.5px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.ps-card__rating {
+  font-family: var(--wr-sans);
+  font-size: 13px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--wr-yes);
+}
+
+.ps-card__note {
+  font-family: var(--wr-sans);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--wr-meta);
+}
+
+/* Roster tray */
+.ps-roster {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  padding: 14px 0;
+  border-top: 1px solid var(--wr-rule);
+}
+
+@media (max-width: 700px) {
+  .ps-roster {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.ps-slotbox {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px 10px;
+  border: 1px dashed #3a4560;
+  border-radius: 3px;
+  min-height: 52px;
+}
+
+.ps-slotbox.is-filled {
+  border-style: solid;
+  border-color: var(--wr-yes);
+  animation: ps-fill 0.3s ease;
+}
+
+@keyframes ps-fill {
+  0% { transform: scale(0.95); }
+  60% { transform: scale(1.03); }
+  100% { transform: scale(1); }
+}
+
+.ps-slotbox__pos {
+  font-family: var(--wr-sans);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--wr-meta);
+}
+
+.ps-slotbox__name {
+  font-family: var(--wr-serif);
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--wr-ink);
+}
+
+.ps-slotbox__rating {
+  font-family: var(--wr-sans);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--wr-yes);
+}
+
+.ps-ready {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 0;
+  border-top: 1px solid var(--wr-rule);
+}
+
+.ps-ready__rating {
+  font-family: var(--wr-sans);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--wr-meta);
+}
+
+.ps-ready__rating strong {
+  color: var(--wr-ink);
+  font-size: 16px;
+  margin-left: 6px;
+}
+
+/* Season play */
+.ps-season {
+  padding: 18px 0;
+}
+
+.ps-scoreline {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 14px;
+}
+
+.ps-record {
+  font-family: var(--wr-serif);
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--wr-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.ps-matchup {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 26px;
+  padding: 34px 16px;
+  border-top: 3px double var(--wr-rule-dark);
+  border-bottom: 3px double var(--wr-rule-dark);
+  overflow: hidden;
+}
+
+.ps-matchup__side {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 130px;
+}
+
+.ps-matchup__team {
+  font-family: var(--wr-serif);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--wr-ink);
+  text-align: center;
+}
+
+.ps-matchup__rating {
+  font-family: var(--wr-sans);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--wr-meta);
+}
+
+.ps-matchup__vs {
+  font-family: var(--wr-sans);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--wr-meta);
+}
+
+.ps-matchup__dots {
+  position: absolute;
+  bottom: 10px;
+  display: flex;
+  gap: 4px;
+}
+
+.ps-matchup__dots span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--wr-meta);
+  animation: wr-typing 1.1s infinite ease-in-out;
+}
+
+.ps-matchup__dots span:nth-child(2) { animation-delay: 0.15s; }
+.ps-matchup__dots span:nth-child(3) { animation-delay: 0.3s; }
+
+/* Rubber-stamp result */
+.ps-stamp {
+  position: absolute;
+  font-family: var(--wr-sans);
+  font-size: 30px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  padding: 6px 18px;
+  border: 3px solid currentColor;
+  border-radius: 4px;
+  transform: rotate(-8deg);
+  animation: ps-stamp 0.35s cubic-bezier(0.2, 1.2, 0.4, 1) both;
+}
+
+.ps-stamp--w { color: var(--wr-yes); }
+.ps-stamp--l { color: var(--wr-no); }
+
+@keyframes ps-stamp {
+  0% {
+    opacity: 0;
+    transform: scale(2.6) rotate(-16deg);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(0.94) rotate(-7deg);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(-8deg);
+  }
+}
+
+.ps-stamp--l {
+  animation: ps-stamp 0.35s cubic-bezier(0.2, 1.2, 0.4, 1) both,
+    ps-shake 0.4s ease 0.35s;
+}
+
+@keyframes ps-shake {
+  0%, 100% { transform: scale(1) rotate(-8deg) translateX(0); }
+  25% { transform: scale(1) rotate(-8deg) translateX(-5px); }
+  50% { transform: scale(1) rotate(-8deg) translateX(5px); }
+  75% { transform: scale(1) rotate(-8deg) translateX(-3px); }
+}
+
+/* Season progress strip */
+.ps-strip {
+  display: flex;
+  gap: 5px;
+  justify-content: center;
+  padding: 16px 0 4px;
+  flex-wrap: wrap;
+}
+
+.ps-strip__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  border: 1px solid #3a4560;
+}
+
+.ps-strip__dot.is-w { background: var(--wr-yes); border-color: var(--wr-yes); }
+.ps-strip__dot.is-l { background: var(--wr-no); border-color: var(--wr-no); }
+.ps-strip__dot.is-now { box-shadow: 0 0 0 2px var(--wr-rule); }
+
+/* Final card */
+.ps-final--perfect .ps-score { color: var(--wr-yes); }
+.ps-final--loss .ps-score { color: var(--wr-no); }
+
+.ps-reward {
+  margin: 0 0 20px;
+  font-family: var(--wr-sans);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--wr-ink);
+}
+
+/* Confetti for 20-0 */
+.ps-confetti {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.ps-confetti span {
+  position: absolute;
+  top: -12px;
+  width: 7px;
+  height: 11px;
+  background: var(--wr-yes);
+  animation: ps-confetti 2.6s linear infinite;
+}
+
+.ps-confetti span:nth-child(3n) { background: var(--wr-no); }
+.ps-confetti span:nth-child(3n + 1) { background: var(--wr-ink); }
+
+@keyframes ps-confetti {
+  to {
+    transform: translateY(340px) rotate(540deg);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ps-pop,
+  .ps-card,
+  .ps-slotbox.is-filled,
+  .ps-stamp,
+  .ps-slot__name {
+    animation: none;
+  }
+  .ps-confetti {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a second War Room game mode inspired by 82-0.com: **Perfect Season** — spin for an era of Cowboys history, draft an all-time roster, then face 20 legendary opponents one reveal at a time chasing 20-0. A tab switcher toggles between it and the Polymarket-style markets, and every phase pops in with entrance animations.

## Gameplay
- **Spin**: slot-reel animation lands on an era ('70s Doomsday, '90s Dynasty, '00s Grit, '10s Squad, '20s Stars), each with rated all-time players
- **Draft**: pick one player per pool into an 8-slot roster; 3 skips; card-deal and roster-snap animations
- **Season**: 17 regular-season games + 3 playoff monsters from 22 legendary opponents; Elo-style win probability; rubber-stamp WIN/LOSS animations (shake on loss); one loss ends the run
- **Finale**: confetti on a perfect 20-0; "Run it back" restart
- **Star Coins**: new Pro-gated `POST /api/warroom/season/reward` pays 5 coins/win + 500 perfect bonus (per-minute cooldown, 0–20 validation); wallet updates live and flows into the existing leaderboard

## Testing
- Reward endpoint smoke tests pass (payout math, cooldown, validation)
- Full game played end-to-end in a headless browser (draft → season → reward claimed) with zero page errors; `prefers-reduced-motion` disables animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDcSUtGdkAWcmGxyZ2HjPE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDcSUtGdkAWcmGxyZ2HjPE)_