### PR TITLE
Expand Perfect Season to 19 NFL team-eras with 192 fairly-rated players

### DIFF
--- a/frontend/src/components/PerfectSeason.jsx
+++ b/frontend/src/components/PerfectSeason.jsx
@@ -3,14 +3,30 @@ import { api } from "../api";
 
 /*
  * Perfect Season — the War Room's second game mode, inspired by 82-0.com.
- * Spin the wheel for an era of Cowboys history, draft an all-time roster
+ * Spin the wheel for a legendary NFL team-era, draft an all-time roster
  * from each pool, then play a 20-game season one reveal at a time chasing
  * 20-0. Wins pay out Star Coins into the same wallet as the markets.
  */
 
 const ERAS = [
   {
-    name: "'70s Doomsday",
+    name: "'70s Steelers",
+    players: [
+      { name: "Terry Bradshaw", pos: "QB", rating: 89 },
+      { name: "Franco Harris", pos: "RB", rating: 91 },
+      { name: "Lynn Swann", pos: "WR", rating: 88 },
+      { name: "John Stallworth", pos: "WR", rating: 89 },
+      { name: "Bennie Cunningham", pos: "TE", rating: 82 },
+      { name: "Mike Webster", pos: "OL", rating: 95 },
+      { name: "Joe Greene", pos: "DL", rating: 97 },
+      { name: "Jack Lambert", pos: "LB", rating: 95 },
+      { name: "Jack Ham", pos: "LB", rating: 94 },
+      { name: "Mel Blount", pos: "DB", rating: 94 },
+      { name: "Donnie Shell", pos: "DB", rating: 88 }
+    ]
+  },
+  {
+    name: "'70s Doomsday Cowboys",
     players: [
       { name: "Roger Staubach", pos: "QB", rating: 94 },
       { name: "Tony Dorsett", pos: "RB", rating: 93 },
@@ -25,7 +41,54 @@ const ERAS = [
     ]
   },
   {
-    name: "'90s Dynasty",
+    name: "'80s 49ers",
+    players: [
+      { name: "Joe Montana", pos: "QB", rating: 97 },
+      { name: "Roger Craig", pos: "RB", rating: 90 },
+      { name: "Jerry Rice", pos: "WR", rating: 99 },
+      { name: "Dwight Clark", pos: "WR", rating: 87 },
+      { name: "Brent Jones", pos: "TE", rating: 85 },
+      { name: "Randy Cross", pos: "OL", rating: 88 },
+      { name: "Jesse Sapolu", pos: "OL", rating: 84 },
+      { name: "Fred Dean", pos: "DL", rating: 89 },
+      { name: "Charles Haley", pos: "LB", rating: 91 },
+      { name: "Ronnie Lott", pos: "DB", rating: 97 },
+      { name: "Eric Wright", pos: "DB", rating: 86 }
+    ]
+  },
+  {
+    name: "'85 Bears",
+    players: [
+      { name: "Jim McMahon", pos: "QB", rating: 84 },
+      { name: "Walter Payton", pos: "RB", rating: 98 },
+      { name: "Willie Gault", pos: "WR", rating: 85 },
+      { name: "Emery Moorehead", pos: "TE", rating: 80 },
+      { name: "Jimbo Covert", pos: "OL", rating: 91 },
+      { name: "Richard Dent", pos: "DL", rating: 93 },
+      { name: "Dan Hampton", pos: "DL", rating: 92 },
+      { name: "Mike Singletary", pos: "LB", rating: 95 },
+      { name: "Otis Wilson", pos: "LB", rating: 87 },
+      { name: "Dave Duerson", pos: "DB", rating: 86 },
+      { name: "Gary Fencik", pos: "DB", rating: 85 }
+    ]
+  },
+  {
+    name: "'86 Giants",
+    players: [
+      { name: "Phil Simms", pos: "QB", rating: 86 },
+      { name: "Joe Morris", pos: "RB", rating: 85 },
+      { name: "Lionel Manuel", pos: "WR", rating: 80 },
+      { name: "Mark Bavaro", pos: "TE", rating: 90 },
+      { name: "Brad Benson", pos: "OL", rating: 82 },
+      { name: "Leonard Marshall", pos: "DL", rating: 87 },
+      { name: "Lawrence Taylor", pos: "LB", rating: 99 },
+      { name: "Harry Carson", pos: "LB", rating: 90 },
+      { name: "Carl Banks", pos: "LB", rating: 88 },
+      { name: "Mark Collins", pos: "DB", rating: 84 }
+    ]
+  },
+  {
+    name: "'90s Cowboys Dynasty",
     players: [
       { name: "Troy Aikman", pos: "QB", rating: 93 },
       { name: "Emmitt Smith", pos: "RB", rating: 97 },
@@ -40,7 +103,98 @@ const ERAS = [
     ]
   },
   {
-    name: "'00s Grit",
+    name: "'90s Packers",
+    players: [
+      { name: "Brett Favre", pos: "QB", rating: 94 },
+      { name: "Dorsey Levens", pos: "RB", rating: 84 },
+      { name: "Antonio Freeman", pos: "WR", rating: 86 },
+      { name: "Robert Brooks", pos: "WR", rating: 84 },
+      { name: "Mark Chmura", pos: "TE", rating: 84 },
+      { name: "Frank Winters", pos: "OL", rating: 84 },
+      { name: "Reggie White", pos: "DL", rating: 98 },
+      { name: "Santana Dotson", pos: "DL", rating: 84 },
+      { name: "Wayne Simmons", pos: "LB", rating: 82 },
+      { name: "LeRoy Butler", pos: "DB", rating: 91 }
+    ]
+  },
+  {
+    name: "'90s Lions",
+    players: [
+      { name: "Scott Mitchell", pos: "QB", rating: 78 },
+      { name: "Barry Sanders", pos: "RB", rating: 99 },
+      { name: "Herman Moore", pos: "WR", rating: 89 },
+      { name: "Brett Perriman", pos: "WR", rating: 83 },
+      { name: "David Sloan", pos: "TE", rating: 78 },
+      { name: "Lomas Brown", pos: "OL", rating: 89 },
+      { name: "Robert Porcher", pos: "DL", rating: 85 },
+      { name: "Chris Spielman", pos: "LB", rating: 87 },
+      { name: "Bennie Blades", pos: "DB", rating: 83 }
+    ]
+  },
+  {
+    name: "'99 Rams (Greatest Show)",
+    players: [
+      { name: "Kurt Warner", pos: "QB", rating: 92 },
+      { name: "Marshall Faulk", pos: "RB", rating: 96 },
+      { name: "Isaac Bruce", pos: "WR", rating: 92 },
+      { name: "Torry Holt", pos: "WR", rating: 91 },
+      { name: "Roland Williams", pos: "TE", rating: 80 },
+      { name: "Orlando Pace", pos: "OL", rating: 96 },
+      { name: "Kevin Carter", pos: "DL", rating: 90 },
+      { name: "D'Marco Farr", pos: "DL", rating: 84 },
+      { name: "London Fletcher", pos: "LB", rating: 88 },
+      { name: "Todd Lyght", pos: "DB", rating: 85 }
+    ]
+  },
+  {
+    name: "'00 Ravens Defense",
+    players: [
+      { name: "Trent Dilfer", pos: "QB", rating: 78 },
+      { name: "Jamal Lewis", pos: "RB", rating: 89 },
+      { name: "Qadry Ismail", pos: "WR", rating: 81 },
+      { name: "Shannon Sharpe", pos: "TE", rating: 92 },
+      { name: "Jonathan Ogden", pos: "OL", rating: 97 },
+      { name: "Sam Adams", pos: "DL", rating: 87 },
+      { name: "Tony Siragusa", pos: "DL", rating: 84 },
+      { name: "Ray Lewis", pos: "LB", rating: 99 },
+      { name: "Peter Boulware", pos: "LB", rating: 87 },
+      { name: "Rod Woodson", pos: "DB", rating: 94 },
+      { name: "Chris McAlister", pos: "DB", rating: 88 }
+    ]
+  },
+  {
+    name: "'00s Patriots",
+    players: [
+      { name: "Tom Brady", pos: "QB", rating: 99 },
+      { name: "Corey Dillon", pos: "RB", rating: 88 },
+      { name: "Randy Moss", pos: "WR", rating: 97 },
+      { name: "Troy Brown", pos: "WR", rating: 85 },
+      { name: "Ben Watson", pos: "TE", rating: 82 },
+      { name: "Matt Light", pos: "OL", rating: 86 },
+      { name: "Richard Seymour", pos: "DL", rating: 93 },
+      { name: "Vince Wilfork", pos: "DL", rating: 90 },
+      { name: "Tedy Bruschi", pos: "LB", rating: 88 },
+      { name: "Ty Law", pos: "DB", rating: 92 },
+      { name: "Rodney Harrison", pos: "DB", rating: 90 }
+    ]
+  },
+  {
+    name: "'00s Colts",
+    players: [
+      { name: "Peyton Manning", pos: "QB", rating: 98 },
+      { name: "Edgerrin James", pos: "RB", rating: 92 },
+      { name: "Marvin Harrison", pos: "WR", rating: 96 },
+      { name: "Reggie Wayne", pos: "WR", rating: 92 },
+      { name: "Dallas Clark", pos: "TE", rating: 88 },
+      { name: "Jeff Saturday", pos: "OL", rating: 90 },
+      { name: "Dwight Freeney", pos: "DL", rating: 93 },
+      { name: "Robert Mathis", pos: "DL", rating: 90 },
+      { name: "Gary Brackett", pos: "LB", rating: 82 },
+      { name: "Bob Sanders", pos: "DB", rating: 89 }
+    ]
+  },
+  {
+    name: "'00s Cowboys Grit",
     players: [
       { name: "Tony Romo", pos: "QB", rating: 89 },
       { name: "Marion Barber", pos: "RB", rating: 84 },
@@ -50,27 +204,86 @@ const ERAS = [
       { name: "La'Roi Glover", pos: "DL", rating: 88 },
       { name: "DeMarcus Ware", pos: "LB", rating: 96 },
       { name: "Terence Newman", pos: "DB", rating: 86 },
-      { name: "Roy Williams", pos: "DB", rating: 87 },
-      { name: "Miles Austin", pos: "WR", rating: 85 }
+      { name: "Roy Williams", pos: "DB", rating: 87 }
     ]
   },
   {
-    name: "'10s Squad",
+    name: "'10s Seahawks (LOB)",
+    players: [
+      { name: "Russell Wilson", pos: "QB", rating: 90 },
+      { name: "Marshawn Lynch", pos: "RB", rating: 93 },
+      { name: "Doug Baldwin", pos: "WR", rating: 87 },
+      { name: "Zach Miller", pos: "TE", rating: 83 },
+      { name: "Max Unger", pos: "OL", rating: 88 },
+      { name: "Michael Bennett", pos: "DL", rating: 88 },
+      { name: "Cliff Avril", pos: "DL", rating: 86 },
+      { name: "Bobby Wagner", pos: "LB", rating: 95 },
+      { name: "Richard Sherman", pos: "DB", rating: 94 },
+      { name: "Earl Thomas", pos: "DB", rating: 95 },
+      { name: "Kam Chancellor", pos: "DB", rating: 91 }
+    ]
+  },
+  {
+    name: "'10s Patriots",
+    players: [
+      { name: "Tom Brady", pos: "QB", rating: 98 },
+      { name: "LeGarrette Blount", pos: "RB", rating: 84 },
+      { name: "Julian Edelman", pos: "WR", rating: 87 },
+      { name: "Rob Gronkowski", pos: "TE", rating: 97 },
+      { name: "Nate Solder", pos: "OL", rating: 85 },
+      { name: "Chandler Jones", pos: "DL", rating: 89 },
+      { name: "Dont'a Hightower", pos: "LB", rating: 88 },
+      { name: "Devin McCourty", pos: "DB", rating: 89 },
+      { name: "Stephon Gilmore", pos: "DB", rating: 93 }
+    ]
+  },
+  {
+    name: "'10s Cowboys",
     players: [
       { name: "Dak Prescott", pos: "QB", rating: 88 },
       { name: "Ezekiel Elliott", pos: "RB", rating: 92 },
       { name: "Dez Bryant", pos: "WR", rating: 91 },
-      { name: "Cole Beasley", pos: "WR", rating: 84 },
+      { name: "Jason Witten", pos: "TE", rating: 89 },
       { name: "Tyron Smith", pos: "OL", rating: 95 },
       { name: "Zack Martin", pos: "OL", rating: 96 },
+      { name: "Travis Frederick", pos: "OL", rating: 93 },
       { name: "DeMarcus Lawrence", pos: "DL", rating: 89 },
       { name: "Sean Lee", pos: "LB", rating: 90 },
-      { name: "Byron Jones", pos: "DB", rating: 87 },
-      { name: "Travis Frederick", pos: "OL", rating: 93 }
+      { name: "Byron Jones", pos: "DB", rating: 87 }
     ]
   },
   {
-    name: "'20s Stars",
+    name: "'20s Chiefs",
+    players: [
+      { name: "Patrick Mahomes", pos: "QB", rating: 99 },
+      { name: "Isiah Pacheco", pos: "RB", rating: 84 },
+      { name: "Tyreek Hill", pos: "WR", rating: 96 },
+      { name: "Travis Kelce", pos: "TE", rating: 98 },
+      { name: "Creed Humphrey", pos: "OL", rating: 92 },
+      { name: "Chris Jones", pos: "DL", rating: 95 },
+      { name: "Frank Clark", pos: "DL", rating: 85 },
+      { name: "Nick Bolton", pos: "LB", rating: 87 },
+      { name: "Trent McDuffie", pos: "DB", rating: 89 },
+      { name: "Justin Reid", pos: "DB", rating: 84 }
+    ]
+  },
+  {
+    name: "'20s 49ers",
+    players: [
+      { name: "Brock Purdy", pos: "QB", rating: 86 },
+      { name: "Christian McCaffrey", pos: "RB", rating: 96 },
+      { name: "Deebo Samuel", pos: "WR", rating: 89 },
+      { name: "Brandon Aiyuk", pos: "WR", rating: 87 },
+      { name: "George Kittle", pos: "TE", rating: 95 },
+      { name: "Trent Williams", pos: "OL", rating: 97 },
+      { name: "Nick Bosa", pos: "DL", rating: 95 },
+      { name: "Fred Warner", pos: "LB", rating: 96 },
+      { name: "Charvarius Ward", pos: "DB", rating: 88 },
+      { name: "Talanoa Hufanga", pos: "DB", rating: 85 }
+    ]
+  },
+  {
+    name: "'20s Cowboys Stars",
     players: [
       { name: "Dak Prescott", pos: "QB", rating: 90 },
       { name: "Tony Pollard", pos: "RB", rating: 86 },
@@ -80,8 +293,7 @@ const ERAS = [
       { name: "Osa Odighizuwa", pos: "DL", rating: 85 },
       { name: "Micah Parsons", pos: "LB", rating: 97 },
       { name: "Trevon Diggs", pos: "DB", rating: 90 },
-      { name: "DaRon Bland", pos: "DB", rating: 89 },
-      { name: "Brandin Cooks", pos: "WR", rating: 84 }
+      { name: "DaRon Bland", pos: "DB", rating: 89 }
     ]
   }
 ];
@@ -137,9 +349,12 @@ function buildSchedule() {
 function rollPool(era, roster) {
   const openSlots = new Set(SLOTS.filter((s) => !roster[s]));
   const pool = shuffle(era.players).slice(0, 7);
-  // Guarantee at least one pickable card so the draft can't dead-end.
+  // Guarantee at least one pickable card so the draft can't dead-end —
+  // rescue from this era first, then from anywhere in the league.
   if (!pool.some((p) => openSlots.has(p.pos))) {
-    const rescue = era.players.find((p) => openSlots.has(p.pos));
+    const rescue =
+      era.players.find((p) => openSlots.has(p.pos)) ||
+      shuffle(ERAS.flatMap((e) => e.players)).find((p) => openSlots.has(p.pos));
     if (rescue) pool[0] = rescue;
   }
   return pool;
@@ -289,10 +504,11 @@ export default function PerfectSeason({ onReward }) {
             Can you go <span className="ps-score">20–0</span>?
           </h2>
           <p className="ps-copy">
-            Spin the wheel for an era of Cowboys history. Draft an all-time
-            roster, one pool at a time. Then survive twenty of the greatest
-            teams ever assembled — lose once and the season is over. Every win
-            pays Star Coins.
+            Spin the wheel for a legendary NFL team-era — the '70s Steelers,
+            the '85 Bears, the '00s Patriots, the Doomsday Cowboys. Draft an
+            all-time roster, one pool at a time. Then survive twenty of the
+            greatest teams ever assembled — lose once and the season is over.
+            Every win pays Star Coins.
           </p>
           <button className="wr-btn ps-cta" onClick={startDraft}>
             Spin the wheel
@@ -393,7 +609,7 @@ export default function PerfectSeason({ onReward }) {
           </div>
           <div className="ps-matchup ps-pop" key={gameIndex}>
             <div className="ps-matchup__side">
-              <span className="ps-matchup__team">Your Cowboys</span>
+              <span className="ps-matchup__team">Your Squad</span>
               <span className="ps-matchup__rating">{teamRating(roster).toFixed(0)}</span>
             </div>
             <span className="ps-matchup__vs">vs</span>


### PR DESCRIPTION
## Summary
The Perfect Season spin wheel now covers legendary team-eras from across the whole NFL (like the real 82-0 game), not just Cowboys history — 19 eras, 192 players.

## Eras
'70s Steelers · '70s Doomsday Cowboys · '80s 49ers · '85 Bears · '86 Giants · '90s Cowboys Dynasty · '90s Packers · '90s Lions · '99 Rams (Greatest Show) · '00 Ravens Defense · '00s Patriots · '00s Colts · '00s Cowboys · '10s Seahawks (LOB) · '10s Patriots · '10s Cowboys · '20s Chiefs · '20s 49ers · '20s Cowboys

## Ratings
Calibrated to history: inner-circle greats at 97–99 (Rice 99, Brady 99, LT 99, Ray Lewis 99, Barry 99, Mahomes 99, Payton 98, Deion 98), stars in the low 90s, role players in the low-to-mid 80s — with honest warts kept (Trent Dilfer 78 on the '00 Ravens, Scott Mitchell 78 next to Barry Sanders' 99).

## Robustness
- Every era verified programmatically to cover all 8 roster slots
- Draft-pool rescue now falls back league-wide so a draft can never dead-end

## Testing
Build clean; full game replayed end-to-end in a headless browser with cross-era drafting ('00 Ravens + '90s Packers + Doomsday Cowboys on one roster) and reward payout — zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDcSUtGdkAWcmGxyZ2HjPE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDcSUtGdkAWcmGxyZ2HjPE)_